### PR TITLE
Need to inject spellcheck=false using code.

### DIFF
--- a/src/assets/js/github.js
+++ b/src/assets/js/github.js
@@ -86,6 +86,7 @@ $(function() {
         return;
     }
     $(".chosen-select").chosen({width: "100%", max_selected_options: 3});
+    $(".chosen-container .search-field .chosen-search-input").attr("spellcheck", false);
     // $(".repo-language").click(function() {
     //     var e = this.innerHTML.replace(/ /g, "");
     //     return $("select").val(e).trigger("liszt:updated").change(),

--- a/src/index.html
+++ b/src/index.html
@@ -21,7 +21,7 @@ css:
 <div class="panel panel-no-border padding-leader-1 padding-trailer-1">
   <div class="grid-container">
     <div class="column-18 tablet-column-11 phone-column-5 line-height-less">
-      <select data-placeholder="Search by topic&hellip;" class="chosen-select" spellcheck="false" multiple tabindex="1">
+      <select data-placeholder="Search by topic&hellip;" class="chosen-select" multiple tabindex="1">
         <optgroup id='esri-topic-list' label="Topics">
           <option value=""></option>
           {{ topicOptions(data.searchTags.topics) }}


### PR DESCRIPTION
chosen-js doesn't seem to allow arbitrary attributes to be specified in HTML for the generate `<input>` tag.

We must wait until we've initialized the chosen-js library and then attach the attribute in code.

See issue #88.