### PR TITLE
display more accurate repo counts when folks search popular topics

### DIFF
--- a/src/assets/js/github.js
+++ b/src/assets/js/github.js
@@ -20,8 +20,7 @@ function showQueryResults(tags, response) {
     showElement($(".spinner-container"), false);
     showElement($("#numReposFound"), true);
     if (!response.message) {
-        var items = response.items || [];
-        $('#numReposFound').html(items.length);
+        $('#numReposFound').html(response.total_count);
     } else if (response.message && response.message.indexOf('API rate limit exceeded') > -1) {
         showElement($("#numReposFound"), false);
         console.error("GitHub API rate limit exceeded...");


### PR DESCRIPTION
the github search api paginates items in sets of 30, so lets just pluck the `total_count` instead

https://api.github.com/search/repositories?q=topic:javascript+org:Esri&sort=stars&order=desc
```js
{
  "total_count": 78,
  "incomplete_results": false,
  "items": [].length = 30
```