### PR TITLE
Fix URL for Calcite-web link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ You can find a complete list of searchable topics in [`search-topics.yml`](src/d
 
 ## Development
 
-The website is generated using the open source static site generator [`acetate`](https://github.com/patrickarlt/acetate) and styled with the help of [`calcite-web`](https:esri.github.io/calcite-web/).
+The website is generated using the open source static site generator [`acetate`](https://github.com/patrickarlt/acetate) and styled with the help of [`calcite-web`](https://esri.github.io/calcite-web/).
 
 1. Fork and clone the project
 2. Install the [`package.json`](package.json) dependencies by running `npm install`


### PR DESCRIPTION
The URL for Calcite-web is missing its slashes. I'm _not_ sure why the LICENSE lines at the bottom show a diff since I didn't go near them while editing. Whitespace automatically removed by the editor perhaps? It doesn't seem like there was harm.