### PR TITLE
Updating license link in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,4 +57,4 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-A copy of the license is available in the repository's [LICENSE](https://raw.github.com/Esri/esri.github.com/master/license.txt) file.
+A copy of the license is available in the repository's [LICENSE](https://raw.github.com/Esri/esri.github.com/master/LICENSE) file.


### PR DESCRIPTION
Updating license link in the README file for [issue #155](https://github.com/Esri/esri.github.io/issues/155)